### PR TITLE
Independent vertical scroll for Components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 
 import { Searchbar, Sidebar, MusicPlayer, TopPlay } from './components';
 import { ArtistDetails, TopArtists, AroundYou, Discover, Search, SongDetails, TopCharts } from './pages';
- 
+
 const App = () => {
   const { activeSong } = useSelector((state) => state.player);
 
@@ -25,7 +25,7 @@ const App = () => {
               <Route path="/search/:searchTerm" element={<Search />} />
             </Routes>
           </div>
-          <div className="xl:sticky relative top-0 h-fit">
+          <div className="xl:sticky relative top-0 max-h-fit overflow-y-auto custom-scrollbar">
             <TopPlay />
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,4 +43,23 @@ module.exports = {
       },
     },
   },
+  plugins: [
+    function ({ addUtilities }) {
+      const newUtilities = {
+        '.custom-scrollbar': {
+          /* For WebKit browsers (Chrome, Safari) */
+          '&::-webkit-scrollbar': {
+            width: '0px',
+          },
+
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: '#4a5568',
+            borderRadius: '5px',
+          },
+        },
+      };
+
+      addUtilities(newUtilities, ['responsive', 'hover']);
+    },
+  ],
 };


### PR DESCRIPTION
While working on the project, I noticed that on larger screens cannot scroll on the TopChart component to see the complete render except when the Discover component has gotten to the end, so to allow for independent scrolling for each component, a custom vertical scroll was set up and can be used by any component that renders on the home screen.

